### PR TITLE
Fix issue #40: fast apiサーバーにDELETE処理を追加する

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,3 +27,9 @@ async def create_item(item: Item):
 @app.get("/items/")
 async def read_items():
     return {"items": data_store}
+@app.delete("/items/")
+async def delete_item(item: str):
+    if item in data_store:
+        data_store.remove(item)
+        return {"message": "Item deleted", "item": item}
+    return {"message": "Item not found", "item": item}

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -18,3 +18,17 @@ def test_read_items():
     assert response.status_code == 200
     assert "テストアイテム1" in response.json()["items"]
     assert "テストアイテム2" in response.json()["items"] 
+
+def test_delete_item():
+    # アイテムを追加
+    client.post("/items/", json={"name": "削除アイテム"})
+
+    # アイテムを削除
+    response = client.delete("/items/", params={"item": "削除アイテム"})
+    assert response.status_code == 200
+    assert response.json() == {"message": "Item deleted", "item": "削除アイテム"}
+
+    # 削除されたことを確認
+    response = client.get("/items/")
+    assert response.status_code == 200
+    assert "削除アイテム" not in response.json()["items"]


### PR DESCRIPTION
This pull request fixes #40.

The issue has been successfully resolved. The changes made include the addition of a DELETE method to the /items endpoint in the main.py file. This method takes an item as a string parameter and removes it from the data_store if it exists, returning a message indicating whether the item was deleted or not found. Additionally, test cases were added to test_main.py to ensure the DELETE method works as expected. The test cases include adding an item, deleting it, and verifying that it no longer exists in the data store. These changes fulfill the requirements outlined in the issue description, confirming that the DELETE functionality is implemented and tested correctly.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌